### PR TITLE
Convert collection.find() to a list and get its length instead of using .count(), which is removed in Pymongo 4.0 and beyond.

### DIFF
--- a/BellRingMatch.py
+++ b/BellRingMatch.py
@@ -294,7 +294,7 @@ def get_new_bellringer(bellringer_form, bellringer_collection):
     all_bellringers = read_xls(bellringer_form)
     new_bellringers = []
     for br in all_bellringers:
-        if bellringer_collection.find({'_id':br.db_id}).count() == 0:
+        if len(list(bellringer_collection.find({'_id':br.db_id}))) == 0:
             new_bellringers.append(br)
             print("   Found new bell ringer:")
             br.print_person()


### PR DESCRIPTION
Convert collection.find() to a list and get its length instead of using .count(), which is removed in Pymongo 4.0 and beyond.